### PR TITLE
V2.1.0

### DIFF
--- a/.github/workflows/flusmic.yaml
+++ b/.github/workflows/flusmic.yaml
@@ -17,7 +17,7 @@ jobs:
         working-directory: packages/flusmic
     runs-on: ubuntu-latest
     container:
-      image: google/dart:2.8.1
+      image: google/dart:2.10.0
     steps:
       - uses: actions/checkout@v2
       - name: get dependencies
@@ -29,7 +29,7 @@ jobs:
       - name: run tests
         run: pub run test_coverage
       - name: check coverage percentage
-        uses: ChicagoFlutter/lcov-cop@v1.0.0
+        uses: VeryGoodOpenSource/very_good_coverage@v1.1.1
         with:
           path: "./packages/flusmic/coverage/lcov.info"
           min_coverage: 95

--- a/packages/flusmic/CHANGELOG.md
+++ b/packages/flusmic/CHANGELOG.md
@@ -1,3 +1,9 @@
+## [2.1.0]
+* Fix 'des' issue with orderings
+* 'page' param for `getRootDocument` and `getDocumentsByType` methods
+* **BREAKING**: Change `Ordering` constructors to `type`, `document`, `firstPublicationDate` and `lastPublicationDate` 
+* Update dependencies.
+
 ## [2.0.0+2]
 * Update dependencies.
 

--- a/packages/flusmic/README.md
+++ b/packages/flusmic/README.md
@@ -1,5 +1,5 @@
 # flusmic
-[![pub](https://img.shields.io/badge/pub-2.0.0+2-blue)](https://pub.dev/packages/flusmic)
+[![pub](https://img.shields.io/badge/pub-2.1.0-blue)](https://pub.dev/packages/flusmic)
 ![flusmic](https://github.com/PixelaGt/flusmic/workflows/flusmic/badge.svg?branch=master&event=push)
 [![codecov](https://codecov.io/gh/PixelaGt/flusmic/branch/master/graph/badge.svg)](https://codecov.io/gh/PixelaGt/flusmic)
 [![Project Status: Active](https://www.repostatus.org/badges/latest/active.svg)](https://www.repostatus.org/#active)
@@ -14,7 +14,7 @@ Add Flusmic in your pubspec.yaml file.
 
 ```yaml
 dependencies:
-  flusmic: 2.0.0 /// latest version
+  flusmic: 2.1.0 /// latest version
 ```
 
 Create an instance of `Flusmic`:

--- a/packages/flusmic/lib/src/flusmic_repository.dart
+++ b/packages/flusmic/lib/src/flusmic_repository.dart
@@ -204,7 +204,12 @@ class Flusmic {
           '&q=[[date.hour-before(${p.path.toString()}, ${p.hour})]]');
 
   String _generateOrdering(Ordering ordering) {
-    final descending = ordering.descending ? ' des' : '';
-    return 'my.${ordering.customType}.${ordering.field}$descending';
+    final descending = ordering.descending ? ' desc' : '';
+    return ordering.map(
+      document: (o) => 'document.${o.type}$descending',
+      firstPublicationDate: (o) => 'document.first_publication_date$descending',
+      lastPublicationDate: (o) => 'document.last_publication_date$descending',
+      type: (o) => 'my.${o.customType}.${o.field}$descending',
+    );
   }
 }

--- a/packages/flusmic/lib/src/flusmic_repository.dart
+++ b/packages/flusmic/lib/src/flusmic_repository.dart
@@ -89,15 +89,15 @@ class Flusmic {
   ///Get the API root document of prismic repository
   ///Contains all the documents.
   Future<FlusmicResponse> getRootDocument(
-          {String language, String authToken}) async =>
-      await query([], authToken: authToken, language: language);
+          {String language, String authToken, int page = 1}) async =>
+      await query([], authToken: authToken, language: language, page: page);
 
   /// Fetch documents by type
   /// Get all the documents by [type] using the slug.
   Future<FlusmicResponse> getDocumentsByType(String slug,
-          {String language, String authToken}) async =>
+          {String language, String authToken, int page = 1}) async =>
       await query([Predicate.at(DefaultPredicatePath.type(), slug)],
-          authToken: authToken, language: language);
+          authToken: authToken, language: language, page: page);
 
   /// Fetch document by id
   /// Get a documents by [id].

--- a/packages/flusmic/lib/src/models/api/api.freezed.dart
+++ b/packages/flusmic/lib/src/models/api/api.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'api.dart';
 
@@ -12,9 +12,11 @@ Api _$ApiFromJson(Map<String, dynamic> json) {
   return _Api.fromJson(json);
 }
 
+/// @nodoc
 class _$ApiTearOff {
   const _$ApiTearOff();
 
+// ignore: unused_element
   _Api call(
       {@required @JsonKey(name: 'oauth_initiate') String oauthInitiate,
       @required @JsonKey(name: 'oauth_token') String oauthToken,
@@ -33,11 +35,18 @@ class _$ApiTearOff {
       types: types,
     );
   }
+
+// ignore: unused_element
+  Api fromJson(Map<String, Object> json) {
+    return Api.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Api = _$ApiTearOff();
 
+/// @nodoc
 mixin _$Api {
   @JsonKey(name: 'oauth_initiate')
   String get oauthInitiate;
@@ -53,6 +62,7 @@ mixin _$Api {
   $ApiCopyWith<Api> get copyWith;
 }
 
+/// @nodoc
 abstract class $ApiCopyWith<$Res> {
   factory $ApiCopyWith(Api value, $Res Function(Api) then) =
       _$ApiCopyWithImpl<$Res>;
@@ -66,6 +76,7 @@ abstract class $ApiCopyWith<$Res> {
       Map<String, String> types});
 }
 
+/// @nodoc
 class _$ApiCopyWithImpl<$Res> implements $ApiCopyWith<$Res> {
   _$ApiCopyWithImpl(this._value, this._then);
 
@@ -99,6 +110,7 @@ class _$ApiCopyWithImpl<$Res> implements $ApiCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$ApiCopyWith<$Res> implements $ApiCopyWith<$Res> {
   factory _$ApiCopyWith(_Api value, $Res Function(_Api) then) =
       __$ApiCopyWithImpl<$Res>;
@@ -113,6 +125,7 @@ abstract class _$ApiCopyWith<$Res> implements $ApiCopyWith<$Res> {
       Map<String, String> types});
 }
 
+/// @nodoc
 class __$ApiCopyWithImpl<$Res> extends _$ApiCopyWithImpl<$Res>
     implements _$ApiCopyWith<$Res> {
   __$ApiCopyWithImpl(_Api _value, $Res Function(_Api) _then)
@@ -148,6 +161,8 @@ class __$ApiCopyWithImpl<$Res> extends _$ApiCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Api implements _Api {
   _$_Api(
       {@required @JsonKey(name: 'oauth_initiate') this.oauthInitiate,

--- a/packages/flusmic/lib/src/models/api/ref.freezed.dart
+++ b/packages/flusmic/lib/src/models/api/ref.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'ref.dart';
 
@@ -12,9 +12,11 @@ Ref _$RefFromJson(Map<String, dynamic> json) {
   return _Ref.fromJson(json);
 }
 
+/// @nodoc
 class _$RefTearOff {
   const _$RefTearOff();
 
+// ignore: unused_element
   _Ref call(
       {@required String id,
       @required String label,
@@ -27,11 +29,18 @@ class _$RefTearOff {
       isMasterRef: isMasterRef,
     );
   }
+
+// ignore: unused_element
+  Ref fromJson(Map<String, Object> json) {
+    return Ref.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Ref = _$RefTearOff();
 
+/// @nodoc
 mixin _$Ref {
   String get id;
   String get label;
@@ -42,12 +51,14 @@ mixin _$Ref {
   $RefCopyWith<Ref> get copyWith;
 }
 
+/// @nodoc
 abstract class $RefCopyWith<$Res> {
   factory $RefCopyWith(Ref value, $Res Function(Ref) then) =
       _$RefCopyWithImpl<$Res>;
   $Res call({String id, String label, String ref, bool isMasterRef});
 }
 
+/// @nodoc
 class _$RefCopyWithImpl<$Res> implements $RefCopyWith<$Res> {
   _$RefCopyWithImpl(this._value, this._then);
 
@@ -72,6 +83,7 @@ class _$RefCopyWithImpl<$Res> implements $RefCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$RefCopyWith<$Res> implements $RefCopyWith<$Res> {
   factory _$RefCopyWith(_Ref value, $Res Function(_Ref) then) =
       __$RefCopyWithImpl<$Res>;
@@ -79,6 +91,7 @@ abstract class _$RefCopyWith<$Res> implements $RefCopyWith<$Res> {
   $Res call({String id, String label, String ref, bool isMasterRef});
 }
 
+/// @nodoc
 class __$RefCopyWithImpl<$Res> extends _$RefCopyWithImpl<$Res>
     implements _$RefCopyWith<$Res> {
   __$RefCopyWithImpl(_Ref _value, $Res Function(_Ref) _then)
@@ -105,6 +118,8 @@ class __$RefCopyWithImpl<$Res> extends _$RefCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Ref implements _Ref {
   _$_Ref(
       {@required this.id,

--- a/packages/flusmic/lib/src/models/document/document.freezed.dart
+++ b/packages/flusmic/lib/src/models/document/document.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'document.dart';
 
@@ -12,9 +12,11 @@ Document _$DocumentFromJson(Map<String, dynamic> json) {
   return _Document.fromJson(json);
 }
 
+/// @nodoc
 class _$DocumentTearOff {
   const _$DocumentTearOff();
 
+// ignore: unused_element
   _Document call(
       {@JsonKey(name: 'alternate_languages')
           List<AlternateLanguage> alternateLanguages,
@@ -51,11 +53,18 @@ class _$DocumentTearOff {
       uid: uid,
     );
   }
+
+// ignore: unused_element
+  Document fromJson(Map<String, Object> json) {
+    return Document.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Document = _$DocumentTearOff();
 
+/// @nodoc
 mixin _$Document {
   @JsonKey(name: 'alternate_languages')
   List<AlternateLanguage> get alternateLanguages;
@@ -78,6 +87,7 @@ mixin _$Document {
   $DocumentCopyWith<Document> get copyWith;
 }
 
+/// @nodoc
 abstract class $DocumentCopyWith<$Res> {
   factory $DocumentCopyWith(Document value, $Res Function(Document) then) =
       _$DocumentCopyWithImpl<$Res>;
@@ -100,6 +110,7 @@ abstract class $DocumentCopyWith<$Res> {
       String uid});
 }
 
+/// @nodoc
 class _$DocumentCopyWithImpl<$Res> implements $DocumentCopyWith<$Res> {
   _$DocumentCopyWithImpl(this._value, this._then);
 
@@ -147,6 +158,7 @@ class _$DocumentCopyWithImpl<$Res> implements $DocumentCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$DocumentCopyWith<$Res> implements $DocumentCopyWith<$Res> {
   factory _$DocumentCopyWith(_Document value, $Res Function(_Document) then) =
       __$DocumentCopyWithImpl<$Res>;
@@ -170,6 +182,7 @@ abstract class _$DocumentCopyWith<$Res> implements $DocumentCopyWith<$Res> {
       String uid});
 }
 
+/// @nodoc
 class __$DocumentCopyWithImpl<$Res> extends _$DocumentCopyWithImpl<$Res>
     implements _$DocumentCopyWith<$Res> {
   __$DocumentCopyWithImpl(_Document _value, $Res Function(_Document) _then)
@@ -219,6 +232,8 @@ class __$DocumentCopyWithImpl<$Res> extends _$DocumentCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Document implements _Document {
   _$_Document(
       {@JsonKey(name: 'alternate_languages') this.alternateLanguages,

--- a/packages/flusmic/lib/src/models/info/alternate_language.freezed.dart
+++ b/packages/flusmic/lib/src/models/info/alternate_language.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'alternate_language.dart';
 
@@ -12,9 +12,11 @@ AlternateLanguage _$AlternateLanguageFromJson(Map<String, dynamic> json) {
   return _AlternateLanguage.fromJson(json);
 }
 
+/// @nodoc
 class _$AlternateLanguageTearOff {
   const _$AlternateLanguageTearOff();
 
+// ignore: unused_element
   _AlternateLanguage call(
       {@required String id, @required String lang, @required String type}) {
     return _AlternateLanguage(
@@ -23,11 +25,18 @@ class _$AlternateLanguageTearOff {
       type: type,
     );
   }
+
+// ignore: unused_element
+  AlternateLanguage fromJson(Map<String, Object> json) {
+    return AlternateLanguage.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $AlternateLanguage = _$AlternateLanguageTearOff();
 
+/// @nodoc
 mixin _$AlternateLanguage {
   String get id;
   String get lang;
@@ -37,6 +46,7 @@ mixin _$AlternateLanguage {
   $AlternateLanguageCopyWith<AlternateLanguage> get copyWith;
 }
 
+/// @nodoc
 abstract class $AlternateLanguageCopyWith<$Res> {
   factory $AlternateLanguageCopyWith(
           AlternateLanguage value, $Res Function(AlternateLanguage) then) =
@@ -44,6 +54,7 @@ abstract class $AlternateLanguageCopyWith<$Res> {
   $Res call({String id, String lang, String type});
 }
 
+/// @nodoc
 class _$AlternateLanguageCopyWithImpl<$Res>
     implements $AlternateLanguageCopyWith<$Res> {
   _$AlternateLanguageCopyWithImpl(this._value, this._then);
@@ -66,6 +77,7 @@ class _$AlternateLanguageCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 abstract class _$AlternateLanguageCopyWith<$Res>
     implements $AlternateLanguageCopyWith<$Res> {
   factory _$AlternateLanguageCopyWith(
@@ -75,6 +87,7 @@ abstract class _$AlternateLanguageCopyWith<$Res>
   $Res call({String id, String lang, String type});
 }
 
+/// @nodoc
 class __$AlternateLanguageCopyWithImpl<$Res>
     extends _$AlternateLanguageCopyWithImpl<$Res>
     implements _$AlternateLanguageCopyWith<$Res> {
@@ -100,6 +113,8 @@ class __$AlternateLanguageCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_AlternateLanguage implements _AlternateLanguage {
   _$_AlternateLanguage(
       {@required this.id, @required this.lang, @required this.type})

--- a/packages/flusmic/lib/src/models/info/dimension.freezed.dart
+++ b/packages/flusmic/lib/src/models/info/dimension.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'dimension.dart';
 
@@ -12,20 +12,29 @@ Dimension _$DimensionFromJson(Map<String, dynamic> json) {
   return _Dimension.fromJson(json);
 }
 
+/// @nodoc
 class _$DimensionTearOff {
   const _$DimensionTearOff();
 
+// ignore: unused_element
   _Dimension call({@required double height, @required double width}) {
     return _Dimension(
       height: height,
       width: width,
     );
   }
+
+// ignore: unused_element
+  Dimension fromJson(Map<String, Object> json) {
+    return Dimension.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Dimension = _$DimensionTearOff();
 
+/// @nodoc
 mixin _$Dimension {
   double get height;
   double get width;
@@ -34,12 +43,14 @@ mixin _$Dimension {
   $DimensionCopyWith<Dimension> get copyWith;
 }
 
+/// @nodoc
 abstract class $DimensionCopyWith<$Res> {
   factory $DimensionCopyWith(Dimension value, $Res Function(Dimension) then) =
       _$DimensionCopyWithImpl<$Res>;
   $Res call({double height, double width});
 }
 
+/// @nodoc
 class _$DimensionCopyWithImpl<$Res> implements $DimensionCopyWith<$Res> {
   _$DimensionCopyWithImpl(this._value, this._then);
 
@@ -59,6 +70,7 @@ class _$DimensionCopyWithImpl<$Res> implements $DimensionCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$DimensionCopyWith<$Res> implements $DimensionCopyWith<$Res> {
   factory _$DimensionCopyWith(
           _Dimension value, $Res Function(_Dimension) then) =
@@ -67,6 +79,7 @@ abstract class _$DimensionCopyWith<$Res> implements $DimensionCopyWith<$Res> {
   $Res call({double height, double width});
 }
 
+/// @nodoc
 class __$DimensionCopyWithImpl<$Res> extends _$DimensionCopyWithImpl<$Res>
     implements _$DimensionCopyWith<$Res> {
   __$DimensionCopyWithImpl(_Dimension _value, $Res Function(_Dimension) _then)
@@ -88,6 +101,8 @@ class __$DimensionCopyWithImpl<$Res> extends _$DimensionCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Dimension implements _Dimension {
   _$_Dimension({@required this.height, @required this.width})
       : assert(height != null),

--- a/packages/flusmic/lib/src/models/info/language.freezed.dart
+++ b/packages/flusmic/lib/src/models/info/language.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'language.dart';
 
@@ -12,20 +12,29 @@ Language _$LanguageFromJson(Map<String, dynamic> json) {
   return _Language.fromJson(json);
 }
 
+/// @nodoc
 class _$LanguageTearOff {
   const _$LanguageTearOff();
 
+// ignore: unused_element
   _Language call({@required String id, @required String name}) {
     return _Language(
       id: id,
       name: name,
     );
   }
+
+// ignore: unused_element
+  Language fromJson(Map<String, Object> json) {
+    return Language.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Language = _$LanguageTearOff();
 
+/// @nodoc
 mixin _$Language {
   String get id;
   String get name;
@@ -34,12 +43,14 @@ mixin _$Language {
   $LanguageCopyWith<Language> get copyWith;
 }
 
+/// @nodoc
 abstract class $LanguageCopyWith<$Res> {
   factory $LanguageCopyWith(Language value, $Res Function(Language) then) =
       _$LanguageCopyWithImpl<$Res>;
   $Res call({String id, String name});
 }
 
+/// @nodoc
 class _$LanguageCopyWithImpl<$Res> implements $LanguageCopyWith<$Res> {
   _$LanguageCopyWithImpl(this._value, this._then);
 
@@ -59,6 +70,7 @@ class _$LanguageCopyWithImpl<$Res> implements $LanguageCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$LanguageCopyWith<$Res> implements $LanguageCopyWith<$Res> {
   factory _$LanguageCopyWith(_Language value, $Res Function(_Language) then) =
       __$LanguageCopyWithImpl<$Res>;
@@ -66,6 +78,7 @@ abstract class _$LanguageCopyWith<$Res> implements $LanguageCopyWith<$Res> {
   $Res call({String id, String name});
 }
 
+/// @nodoc
 class __$LanguageCopyWithImpl<$Res> extends _$LanguageCopyWithImpl<$Res>
     implements _$LanguageCopyWith<$Res> {
   __$LanguageCopyWithImpl(_Language _value, $Res Function(_Language) _then)
@@ -87,6 +100,8 @@ class __$LanguageCopyWithImpl<$Res> extends _$LanguageCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Language implements _Language {
   _$_Language({@required this.id, @required this.name})
       : assert(id != null),

--- a/packages/flusmic/lib/src/models/query/ordering.dart
+++ b/packages/flusmic/lib/src/models/query/ordering.dart
@@ -8,7 +8,19 @@ part 'ordering.freezed.dart';
 ///querying.
 @freezed
 abstract class Ordering with _$Ordering {
-  ///Deafult factory constructor for Ordering
-  const factory Ordering(String customType, String field,
-      {@Default(false) bool descending}) = _Ordering;
+  ///Custom type Ordering constructor
+  const factory Ordering.type(String customType, String field,
+      {@Default(false) bool descending}) = TypeOrdering;
+
+  ///Document Ordering constructor
+  const factory Ordering.document(String type,
+      {@Default(false) bool descending}) = DocumentOrdering;
+
+  ///First publication date Ordering constructor
+  const factory Ordering.firstPublicationDate(
+      {@Default(false) bool descending}) = FirstPublicationDateOrdering;
+
+  ///Last publication date Ordering constructor
+  const factory Ordering.lastPublicationDate(
+      {@Default(false) bool descending}) = LastPublicationDateOrdering;
 }

--- a/packages/flusmic/lib/src/models/query/ordering.freezed.dart
+++ b/packages/flusmic/lib/src/models/query/ordering.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'ordering.dart';
 
@@ -9,35 +9,93 @@ part of 'ordering.dart';
 
 T _$identity<T>(T value) => value;
 
+/// @nodoc
 class _$OrderingTearOff {
   const _$OrderingTearOff();
 
-  _Ordering call(String customType, String field, {bool descending = false}) {
-    return _Ordering(
+// ignore: unused_element
+  TypeOrdering type(String customType, String field,
+      {bool descending = false}) {
+    return TypeOrdering(
       customType,
       field,
       descending: descending,
     );
   }
+
+// ignore: unused_element
+  DocumentOrdering document(String type, {bool descending = false}) {
+    return DocumentOrdering(
+      type,
+      descending: descending,
+    );
+  }
+
+// ignore: unused_element
+  FirstPublicationDateOrdering firstPublicationDate({bool descending = false}) {
+    return FirstPublicationDateOrdering(
+      descending: descending,
+    );
+  }
+
+// ignore: unused_element
+  LastPublicationDateOrdering lastPublicationDate({bool descending = false}) {
+    return LastPublicationDateOrdering(
+      descending: descending,
+    );
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Ordering = _$OrderingTearOff();
 
+/// @nodoc
 mixin _$Ordering {
-  String get customType;
-  String get field;
   bool get descending;
+
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result type(String customType, String field, bool descending),
+    @required Result document(String type, bool descending),
+    @required Result firstPublicationDate(bool descending),
+    @required Result lastPublicationDate(bool descending),
+  });
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result type(String customType, String field, bool descending),
+    Result document(String type, bool descending),
+    Result firstPublicationDate(bool descending),
+    Result lastPublicationDate(bool descending),
+    @required Result orElse(),
+  });
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result type(TypeOrdering value),
+    @required Result document(DocumentOrdering value),
+    @required Result firstPublicationDate(FirstPublicationDateOrdering value),
+    @required Result lastPublicationDate(LastPublicationDateOrdering value),
+  });
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result type(TypeOrdering value),
+    Result document(DocumentOrdering value),
+    Result firstPublicationDate(FirstPublicationDateOrdering value),
+    Result lastPublicationDate(LastPublicationDateOrdering value),
+    @required Result orElse(),
+  });
 
   $OrderingCopyWith<Ordering> get copyWith;
 }
 
+/// @nodoc
 abstract class $OrderingCopyWith<$Res> {
   factory $OrderingCopyWith(Ordering value, $Res Function(Ordering) then) =
       _$OrderingCopyWithImpl<$Res>;
-  $Res call({String customType, String field, bool descending});
+  $Res call({bool descending});
 }
 
+/// @nodoc
 class _$OrderingCopyWithImpl<$Res> implements $OrderingCopyWith<$Res> {
   _$OrderingCopyWithImpl(this._value, this._then);
 
@@ -47,34 +105,33 @@ class _$OrderingCopyWithImpl<$Res> implements $OrderingCopyWith<$Res> {
 
   @override
   $Res call({
-    Object customType = freezed,
-    Object field = freezed,
     Object descending = freezed,
   }) {
     return _then(_value.copyWith(
-      customType:
-          customType == freezed ? _value.customType : customType as String,
-      field: field == freezed ? _value.field : field as String,
       descending:
           descending == freezed ? _value.descending : descending as bool,
     ));
   }
 }
 
-abstract class _$OrderingCopyWith<$Res> implements $OrderingCopyWith<$Res> {
-  factory _$OrderingCopyWith(_Ordering value, $Res Function(_Ordering) then) =
-      __$OrderingCopyWithImpl<$Res>;
+/// @nodoc
+abstract class $TypeOrderingCopyWith<$Res> implements $OrderingCopyWith<$Res> {
+  factory $TypeOrderingCopyWith(
+          TypeOrdering value, $Res Function(TypeOrdering) then) =
+      _$TypeOrderingCopyWithImpl<$Res>;
   @override
   $Res call({String customType, String field, bool descending});
 }
 
-class __$OrderingCopyWithImpl<$Res> extends _$OrderingCopyWithImpl<$Res>
-    implements _$OrderingCopyWith<$Res> {
-  __$OrderingCopyWithImpl(_Ordering _value, $Res Function(_Ordering) _then)
-      : super(_value, (v) => _then(v as _Ordering));
+/// @nodoc
+class _$TypeOrderingCopyWithImpl<$Res> extends _$OrderingCopyWithImpl<$Res>
+    implements $TypeOrderingCopyWith<$Res> {
+  _$TypeOrderingCopyWithImpl(
+      TypeOrdering _value, $Res Function(TypeOrdering) _then)
+      : super(_value, (v) => _then(v as TypeOrdering));
 
   @override
-  _Ordering get _value => super._value as _Ordering;
+  TypeOrdering get _value => super._value as TypeOrdering;
 
   @override
   $Res call({
@@ -82,7 +139,7 @@ class __$OrderingCopyWithImpl<$Res> extends _$OrderingCopyWithImpl<$Res>
     Object field = freezed,
     Object descending = freezed,
   }) {
-    return _then(_Ordering(
+    return _then(TypeOrdering(
       customType == freezed ? _value.customType : customType as String,
       field == freezed ? _value.field : field as String,
       descending:
@@ -91,8 +148,9 @@ class __$OrderingCopyWithImpl<$Res> extends _$OrderingCopyWithImpl<$Res>
   }
 }
 
-class _$_Ordering implements _Ordering {
-  const _$_Ordering(this.customType, this.field, {this.descending = false})
+/// @nodoc
+class _$TypeOrdering implements TypeOrdering {
+  const _$TypeOrdering(this.customType, this.field, {this.descending = false})
       : assert(customType != null),
         assert(field != null),
         assert(descending != null);
@@ -107,13 +165,13 @@ class _$_Ordering implements _Ordering {
 
   @override
   String toString() {
-    return 'Ordering(customType: $customType, field: $field, descending: $descending)';
+    return 'Ordering.type(customType: $customType, field: $field, descending: $descending)';
   }
 
   @override
   bool operator ==(dynamic other) {
     return identical(this, other) ||
-        (other is _Ordering &&
+        (other is TypeOrdering &&
             (identical(other.customType, customType) ||
                 const DeepCollectionEquality()
                     .equals(other.customType, customType)) &&
@@ -132,20 +190,506 @@ class _$_Ordering implements _Ordering {
       const DeepCollectionEquality().hash(descending);
 
   @override
-  _$OrderingCopyWith<_Ordering> get copyWith =>
-      __$OrderingCopyWithImpl<_Ordering>(this, _$identity);
+  $TypeOrderingCopyWith<TypeOrdering> get copyWith =>
+      _$TypeOrderingCopyWithImpl<TypeOrdering>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result type(String customType, String field, bool descending),
+    @required Result document(String type, bool descending),
+    @required Result firstPublicationDate(bool descending),
+    @required Result lastPublicationDate(bool descending),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return type(customType, field, descending);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result type(String customType, String field, bool descending),
+    Result document(String type, bool descending),
+    Result firstPublicationDate(bool descending),
+    Result lastPublicationDate(bool descending),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (type != null) {
+      return type(customType, field, descending);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result type(TypeOrdering value),
+    @required Result document(DocumentOrdering value),
+    @required Result firstPublicationDate(FirstPublicationDateOrdering value),
+    @required Result lastPublicationDate(LastPublicationDateOrdering value),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return type(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result type(TypeOrdering value),
+    Result document(DocumentOrdering value),
+    Result firstPublicationDate(FirstPublicationDateOrdering value),
+    Result lastPublicationDate(LastPublicationDateOrdering value),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (type != null) {
+      return type(this);
+    }
+    return orElse();
+  }
 }
 
-abstract class _Ordering implements Ordering {
-  const factory _Ordering(String customType, String field, {bool descending}) =
-      _$_Ordering;
+abstract class TypeOrdering implements Ordering {
+  const factory TypeOrdering(String customType, String field,
+      {bool descending}) = _$TypeOrdering;
 
-  @override
   String get customType;
-  @override
   String get field;
   @override
   bool get descending;
   @override
-  _$OrderingCopyWith<_Ordering> get copyWith;
+  $TypeOrderingCopyWith<TypeOrdering> get copyWith;
+}
+
+/// @nodoc
+abstract class $DocumentOrderingCopyWith<$Res>
+    implements $OrderingCopyWith<$Res> {
+  factory $DocumentOrderingCopyWith(
+          DocumentOrdering value, $Res Function(DocumentOrdering) then) =
+      _$DocumentOrderingCopyWithImpl<$Res>;
+  @override
+  $Res call({String type, bool descending});
+}
+
+/// @nodoc
+class _$DocumentOrderingCopyWithImpl<$Res> extends _$OrderingCopyWithImpl<$Res>
+    implements $DocumentOrderingCopyWith<$Res> {
+  _$DocumentOrderingCopyWithImpl(
+      DocumentOrdering _value, $Res Function(DocumentOrdering) _then)
+      : super(_value, (v) => _then(v as DocumentOrdering));
+
+  @override
+  DocumentOrdering get _value => super._value as DocumentOrdering;
+
+  @override
+  $Res call({
+    Object type = freezed,
+    Object descending = freezed,
+  }) {
+    return _then(DocumentOrdering(
+      type == freezed ? _value.type : type as String,
+      descending:
+          descending == freezed ? _value.descending : descending as bool,
+    ));
+  }
+}
+
+/// @nodoc
+class _$DocumentOrdering implements DocumentOrdering {
+  const _$DocumentOrdering(this.type, {this.descending = false})
+      : assert(type != null),
+        assert(descending != null);
+
+  @override
+  final String type;
+  @JsonKey(defaultValue: false)
+  @override
+  final bool descending;
+
+  @override
+  String toString() {
+    return 'Ordering.document(type: $type, descending: $descending)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is DocumentOrdering &&
+            (identical(other.type, type) ||
+                const DeepCollectionEquality().equals(other.type, type)) &&
+            (identical(other.descending, descending) ||
+                const DeepCollectionEquality()
+                    .equals(other.descending, descending)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^
+      const DeepCollectionEquality().hash(type) ^
+      const DeepCollectionEquality().hash(descending);
+
+  @override
+  $DocumentOrderingCopyWith<DocumentOrdering> get copyWith =>
+      _$DocumentOrderingCopyWithImpl<DocumentOrdering>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result type(String customType, String field, bool descending),
+    @required Result document(String type, bool descending),
+    @required Result firstPublicationDate(bool descending),
+    @required Result lastPublicationDate(bool descending),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return document(this.type, descending);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result type(String customType, String field, bool descending),
+    Result document(String type, bool descending),
+    Result firstPublicationDate(bool descending),
+    Result lastPublicationDate(bool descending),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (document != null) {
+      return document(this.type, descending);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result type(TypeOrdering value),
+    @required Result document(DocumentOrdering value),
+    @required Result firstPublicationDate(FirstPublicationDateOrdering value),
+    @required Result lastPublicationDate(LastPublicationDateOrdering value),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return document(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result type(TypeOrdering value),
+    Result document(DocumentOrdering value),
+    Result firstPublicationDate(FirstPublicationDateOrdering value),
+    Result lastPublicationDate(LastPublicationDateOrdering value),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (document != null) {
+      return document(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class DocumentOrdering implements Ordering {
+  const factory DocumentOrdering(String type, {bool descending}) =
+      _$DocumentOrdering;
+
+  String get type;
+  @override
+  bool get descending;
+  @override
+  $DocumentOrderingCopyWith<DocumentOrdering> get copyWith;
+}
+
+/// @nodoc
+abstract class $FirstPublicationDateOrderingCopyWith<$Res>
+    implements $OrderingCopyWith<$Res> {
+  factory $FirstPublicationDateOrderingCopyWith(
+          FirstPublicationDateOrdering value,
+          $Res Function(FirstPublicationDateOrdering) then) =
+      _$FirstPublicationDateOrderingCopyWithImpl<$Res>;
+  @override
+  $Res call({bool descending});
+}
+
+/// @nodoc
+class _$FirstPublicationDateOrderingCopyWithImpl<$Res>
+    extends _$OrderingCopyWithImpl<$Res>
+    implements $FirstPublicationDateOrderingCopyWith<$Res> {
+  _$FirstPublicationDateOrderingCopyWithImpl(
+      FirstPublicationDateOrdering _value,
+      $Res Function(FirstPublicationDateOrdering) _then)
+      : super(_value, (v) => _then(v as FirstPublicationDateOrdering));
+
+  @override
+  FirstPublicationDateOrdering get _value =>
+      super._value as FirstPublicationDateOrdering;
+
+  @override
+  $Res call({
+    Object descending = freezed,
+  }) {
+    return _then(FirstPublicationDateOrdering(
+      descending:
+          descending == freezed ? _value.descending : descending as bool,
+    ));
+  }
+}
+
+/// @nodoc
+class _$FirstPublicationDateOrdering implements FirstPublicationDateOrdering {
+  const _$FirstPublicationDateOrdering({this.descending = false})
+      : assert(descending != null);
+
+  @JsonKey(defaultValue: false)
+  @override
+  final bool descending;
+
+  @override
+  String toString() {
+    return 'Ordering.firstPublicationDate(descending: $descending)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is FirstPublicationDateOrdering &&
+            (identical(other.descending, descending) ||
+                const DeepCollectionEquality()
+                    .equals(other.descending, descending)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(descending);
+
+  @override
+  $FirstPublicationDateOrderingCopyWith<FirstPublicationDateOrdering>
+      get copyWith => _$FirstPublicationDateOrderingCopyWithImpl<
+          FirstPublicationDateOrdering>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result type(String customType, String field, bool descending),
+    @required Result document(String type, bool descending),
+    @required Result firstPublicationDate(bool descending),
+    @required Result lastPublicationDate(bool descending),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return firstPublicationDate(descending);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result type(String customType, String field, bool descending),
+    Result document(String type, bool descending),
+    Result firstPublicationDate(bool descending),
+    Result lastPublicationDate(bool descending),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (firstPublicationDate != null) {
+      return firstPublicationDate(descending);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result type(TypeOrdering value),
+    @required Result document(DocumentOrdering value),
+    @required Result firstPublicationDate(FirstPublicationDateOrdering value),
+    @required Result lastPublicationDate(LastPublicationDateOrdering value),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return firstPublicationDate(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result type(TypeOrdering value),
+    Result document(DocumentOrdering value),
+    Result firstPublicationDate(FirstPublicationDateOrdering value),
+    Result lastPublicationDate(LastPublicationDateOrdering value),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (firstPublicationDate != null) {
+      return firstPublicationDate(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class FirstPublicationDateOrdering implements Ordering {
+  const factory FirstPublicationDateOrdering({bool descending}) =
+      _$FirstPublicationDateOrdering;
+
+  @override
+  bool get descending;
+  @override
+  $FirstPublicationDateOrderingCopyWith<FirstPublicationDateOrdering>
+      get copyWith;
+}
+
+/// @nodoc
+abstract class $LastPublicationDateOrderingCopyWith<$Res>
+    implements $OrderingCopyWith<$Res> {
+  factory $LastPublicationDateOrderingCopyWith(
+          LastPublicationDateOrdering value,
+          $Res Function(LastPublicationDateOrdering) then) =
+      _$LastPublicationDateOrderingCopyWithImpl<$Res>;
+  @override
+  $Res call({bool descending});
+}
+
+/// @nodoc
+class _$LastPublicationDateOrderingCopyWithImpl<$Res>
+    extends _$OrderingCopyWithImpl<$Res>
+    implements $LastPublicationDateOrderingCopyWith<$Res> {
+  _$LastPublicationDateOrderingCopyWithImpl(LastPublicationDateOrdering _value,
+      $Res Function(LastPublicationDateOrdering) _then)
+      : super(_value, (v) => _then(v as LastPublicationDateOrdering));
+
+  @override
+  LastPublicationDateOrdering get _value =>
+      super._value as LastPublicationDateOrdering;
+
+  @override
+  $Res call({
+    Object descending = freezed,
+  }) {
+    return _then(LastPublicationDateOrdering(
+      descending:
+          descending == freezed ? _value.descending : descending as bool,
+    ));
+  }
+}
+
+/// @nodoc
+class _$LastPublicationDateOrdering implements LastPublicationDateOrdering {
+  const _$LastPublicationDateOrdering({this.descending = false})
+      : assert(descending != null);
+
+  @JsonKey(defaultValue: false)
+  @override
+  final bool descending;
+
+  @override
+  String toString() {
+    return 'Ordering.lastPublicationDate(descending: $descending)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is LastPublicationDateOrdering &&
+            (identical(other.descending, descending) ||
+                const DeepCollectionEquality()
+                    .equals(other.descending, descending)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(descending);
+
+  @override
+  $LastPublicationDateOrderingCopyWith<LastPublicationDateOrdering>
+      get copyWith => _$LastPublicationDateOrderingCopyWithImpl<
+          LastPublicationDateOrdering>(this, _$identity);
+
+  @override
+  @optionalTypeArgs
+  Result when<Result extends Object>({
+    @required Result type(String customType, String field, bool descending),
+    @required Result document(String type, bool descending),
+    @required Result firstPublicationDate(bool descending),
+    @required Result lastPublicationDate(bool descending),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return lastPublicationDate(descending);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeWhen<Result extends Object>({
+    Result type(String customType, String field, bool descending),
+    Result document(String type, bool descending),
+    Result firstPublicationDate(bool descending),
+    Result lastPublicationDate(bool descending),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (lastPublicationDate != null) {
+      return lastPublicationDate(descending);
+    }
+    return orElse();
+  }
+
+  @override
+  @optionalTypeArgs
+  Result map<Result extends Object>({
+    @required Result type(TypeOrdering value),
+    @required Result document(DocumentOrdering value),
+    @required Result firstPublicationDate(FirstPublicationDateOrdering value),
+    @required Result lastPublicationDate(LastPublicationDateOrdering value),
+  }) {
+    assert(type != null);
+    assert(document != null);
+    assert(firstPublicationDate != null);
+    assert(lastPublicationDate != null);
+    return lastPublicationDate(this);
+  }
+
+  @override
+  @optionalTypeArgs
+  Result maybeMap<Result extends Object>({
+    Result type(TypeOrdering value),
+    Result document(DocumentOrdering value),
+    Result firstPublicationDate(FirstPublicationDateOrdering value),
+    Result lastPublicationDate(LastPublicationDateOrdering value),
+    @required Result orElse(),
+  }) {
+    assert(orElse != null);
+    if (lastPublicationDate != null) {
+      return lastPublicationDate(this);
+    }
+    return orElse();
+  }
+}
+
+abstract class LastPublicationDateOrdering implements Ordering {
+  const factory LastPublicationDateOrdering({bool descending}) =
+      _$LastPublicationDateOrdering;
+
+  @override
+  bool get descending;
+  @override
+  $LastPublicationDateOrderingCopyWith<LastPublicationDateOrdering>
+      get copyWith;
 }

--- a/packages/flusmic/lib/src/models/query/predicate.freezed.dart
+++ b/packages/flusmic/lib/src/models/query/predicate.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'predicate.dart';
 
@@ -9,9 +9,11 @@ part of 'predicate.dart';
 
 T _$identity<T>(T value) => value;
 
+/// @nodoc
 class _$PredicateTearOff {
   const _$PredicateTearOff();
 
+// ignore: unused_element
   AnyPredicate any(PredicatePath path, List<String> values) {
     return AnyPredicate(
       path,
@@ -19,6 +21,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   AtPredicate at(PredicatePath path, String value) {
     return AtPredicate(
       path,
@@ -26,6 +29,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   FullTextPredicate fullText(PredicatePath path, String value) {
     return FullTextPredicate(
       path,
@@ -33,6 +37,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   GtPredicate gt(PredicatePath path, double value) {
     return GtPredicate(
       path,
@@ -40,12 +45,14 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   HasPredicate has(PredicatePath path) {
     return HasPredicate(
       path,
     );
   }
 
+// ignore: unused_element
   InRangePredicate inRange(
       PredicatePath path, double lowerLimit, double upperLimit) {
     return InRangePredicate(
@@ -55,6 +62,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   InPredicate into(PredicatePath path, List<String> values) {
     return InPredicate(
       path,
@@ -62,6 +70,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   LtPredicate lt(PredicatePath path, double value) {
     return LtPredicate(
       path,
@@ -69,12 +78,14 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   MissingPredicate missing(PredicatePath path) {
     return MissingPredicate(
       path,
     );
   }
 
+// ignore: unused_element
   NearPredicate near(
       PredicatePath path, double latitude, double longitude, double radius) {
     return NearPredicate(
@@ -85,6 +96,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   NotPredicate not(PredicatePath path, String value) {
     return NotPredicate(
       path,
@@ -92,6 +104,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   SimilarPredicate similar(String id, int value) {
     return SimilarPredicate(
       id,
@@ -99,6 +112,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateAfterPredicate dateAfter(PredicatePath path, int epoch) {
     return DateAfterPredicate(
       path,
@@ -106,6 +120,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateBeforePredicate dateBefore(PredicatePath path, int epoch) {
     return DateBeforePredicate(
       path,
@@ -113,6 +128,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateBetweenPredicate dateBetween(
       PredicatePath path, int startEpoch, int endEpoch) {
     return DateBetweenPredicate(
@@ -122,6 +138,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfMonthPredicate dateDayOfMonth(PredicatePath path, int day) {
     return DateDayOfMonthPredicate(
       path,
@@ -129,6 +146,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfMonthAfterPredicate dateDayOfMonthAfter(
       PredicatePath path, int day) {
     return DateDayOfMonthAfterPredicate(
@@ -137,6 +155,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfMonthBeforePredicate dateDayOfMonthBefore(
       PredicatePath path, int day) {
     return DateDayOfMonthBeforePredicate(
@@ -145,6 +164,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfWeekPredicate dateDayOfWeek(PredicatePath path, String day) {
     return DateDayOfWeekPredicate(
       path,
@@ -152,6 +172,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfWeekAfterPredicate dateDayOfWeekAfter(
       PredicatePath path, String day) {
     return DateDayOfWeekAfterPredicate(
@@ -160,6 +181,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateDayOfWeekBeforePredicate dateDayOfWeekBefore(
       PredicatePath path, String day) {
     return DateDayOfWeekBeforePredicate(
@@ -168,6 +190,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateMonthPredicate dateMonth(PredicatePath path, String month) {
     return DateMonthPredicate(
       path,
@@ -175,6 +198,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateMonthAfterPredicate dateMonthAfter(PredicatePath path, String month) {
     return DateMonthAfterPredicate(
       path,
@@ -182,6 +206,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateMonthBeforePredicate dateMonthBefore(PredicatePath path, String month) {
     return DateMonthBeforePredicate(
       path,
@@ -189,6 +214,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateYearPredicate dateYear(PredicatePath path, int year) {
     return DateYearPredicate(
       path,
@@ -196,6 +222,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateHourPredicate hour(PredicatePath path, int hour) {
     return DateHourPredicate(
       path,
@@ -203,6 +230,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateHourAfterPredicate hourAfter(PredicatePath path, int hour) {
     return DateHourAfterPredicate(
       path,
@@ -210,6 +238,7 @@ class _$PredicateTearOff {
     );
   }
 
+// ignore: unused_element
   DateHourBeforePredicate hourBefore(PredicatePath path, int hour) {
     return DateHourBeforePredicate(
       path,
@@ -218,9 +247,11 @@ class _$PredicateTearOff {
   }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Predicate = _$PredicateTearOff();
 
+/// @nodoc
 mixin _$Predicate {
   @optionalTypeArgs
   Result when<Result extends Object>({
@@ -356,11 +387,13 @@ mixin _$Predicate {
   });
 }
 
+/// @nodoc
 abstract class $PredicateCopyWith<$Res> {
   factory $PredicateCopyWith(Predicate value, $Res Function(Predicate) then) =
       _$PredicateCopyWithImpl<$Res>;
 }
 
+/// @nodoc
 class _$PredicateCopyWithImpl<$Res> implements $PredicateCopyWith<$Res> {
   _$PredicateCopyWithImpl(this._value, this._then);
 
@@ -369,6 +402,7 @@ class _$PredicateCopyWithImpl<$Res> implements $PredicateCopyWith<$Res> {
   final $Res Function(Predicate) _then;
 }
 
+/// @nodoc
 abstract class $AnyPredicateCopyWith<$Res> {
   factory $AnyPredicateCopyWith(
           AnyPredicate value, $Res Function(AnyPredicate) then) =
@@ -376,6 +410,7 @@ abstract class $AnyPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, List<String> values});
 }
 
+/// @nodoc
 class _$AnyPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $AnyPredicateCopyWith<$Res> {
   _$AnyPredicateCopyWithImpl(
@@ -397,6 +432,7 @@ class _$AnyPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$AnyPredicate implements AnyPredicate {
   _$AnyPredicate(this.path, this.values)
       : assert(path != null),
@@ -654,6 +690,7 @@ abstract class AnyPredicate implements Predicate {
   $AnyPredicateCopyWith<AnyPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $AtPredicateCopyWith<$Res> {
   factory $AtPredicateCopyWith(
           AtPredicate value, $Res Function(AtPredicate) then) =
@@ -661,6 +698,7 @@ abstract class $AtPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String value});
 }
 
+/// @nodoc
 class _$AtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $AtPredicateCopyWith<$Res> {
   _$AtPredicateCopyWithImpl(
@@ -682,6 +720,7 @@ class _$AtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$AtPredicate implements AtPredicate {
   _$AtPredicate(this.path, this.value)
       : assert(path != null),
@@ -938,6 +977,7 @@ abstract class AtPredicate implements Predicate {
   $AtPredicateCopyWith<AtPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $FullTextPredicateCopyWith<$Res> {
   factory $FullTextPredicateCopyWith(
           FullTextPredicate value, $Res Function(FullTextPredicate) then) =
@@ -945,6 +985,7 @@ abstract class $FullTextPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String value});
 }
 
+/// @nodoc
 class _$FullTextPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $FullTextPredicateCopyWith<$Res> {
@@ -967,6 +1008,7 @@ class _$FullTextPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$FullTextPredicate implements FullTextPredicate {
   _$FullTextPredicate(this.path, this.value)
       : assert(path != null),
@@ -1224,6 +1266,7 @@ abstract class FullTextPredicate implements Predicate {
   $FullTextPredicateCopyWith<FullTextPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $GtPredicateCopyWith<$Res> {
   factory $GtPredicateCopyWith(
           GtPredicate value, $Res Function(GtPredicate) then) =
@@ -1231,6 +1274,7 @@ abstract class $GtPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, double value});
 }
 
+/// @nodoc
 class _$GtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $GtPredicateCopyWith<$Res> {
   _$GtPredicateCopyWithImpl(
@@ -1252,6 +1296,7 @@ class _$GtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$GtPredicate implements GtPredicate {
   _$GtPredicate(this.path, this.value)
       : assert(path != null),
@@ -1508,6 +1553,7 @@ abstract class GtPredicate implements Predicate {
   $GtPredicateCopyWith<GtPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $HasPredicateCopyWith<$Res> {
   factory $HasPredicateCopyWith(
           HasPredicate value, $Res Function(HasPredicate) then) =
@@ -1515,6 +1561,7 @@ abstract class $HasPredicateCopyWith<$Res> {
   $Res call({PredicatePath path});
 }
 
+/// @nodoc
 class _$HasPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $HasPredicateCopyWith<$Res> {
   _$HasPredicateCopyWithImpl(
@@ -1534,6 +1581,7 @@ class _$HasPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$HasPredicate implements HasPredicate {
   _$HasPredicate(this.path) : assert(path != null);
 
@@ -1781,6 +1829,7 @@ abstract class HasPredicate implements Predicate {
   $HasPredicateCopyWith<HasPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $InRangePredicateCopyWith<$Res> {
   factory $InRangePredicateCopyWith(
           InRangePredicate value, $Res Function(InRangePredicate) then) =
@@ -1788,6 +1837,7 @@ abstract class $InRangePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, double lowerLimit, double upperLimit});
 }
 
+/// @nodoc
 class _$InRangePredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $InRangePredicateCopyWith<$Res> {
   _$InRangePredicateCopyWithImpl(
@@ -1811,6 +1861,7 @@ class _$InRangePredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$InRangePredicate implements InRangePredicate {
   _$InRangePredicate(this.path, this.lowerLimit, this.upperLimit)
       : assert(path != null),
@@ -2078,6 +2129,7 @@ abstract class InRangePredicate implements Predicate {
   $InRangePredicateCopyWith<InRangePredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $InPredicateCopyWith<$Res> {
   factory $InPredicateCopyWith(
           InPredicate value, $Res Function(InPredicate) then) =
@@ -2085,6 +2137,7 @@ abstract class $InPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, List<String> values});
 }
 
+/// @nodoc
 class _$InPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $InPredicateCopyWith<$Res> {
   _$InPredicateCopyWithImpl(
@@ -2106,6 +2159,7 @@ class _$InPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$InPredicate implements InPredicate {
   _$InPredicate(this.path, this.values)
       : assert(path != null),
@@ -2362,6 +2416,7 @@ abstract class InPredicate implements Predicate {
   $InPredicateCopyWith<InPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $LtPredicateCopyWith<$Res> {
   factory $LtPredicateCopyWith(
           LtPredicate value, $Res Function(LtPredicate) then) =
@@ -2369,6 +2424,7 @@ abstract class $LtPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, double value});
 }
 
+/// @nodoc
 class _$LtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $LtPredicateCopyWith<$Res> {
   _$LtPredicateCopyWithImpl(
@@ -2390,6 +2446,7 @@ class _$LtPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$LtPredicate implements LtPredicate {
   _$LtPredicate(this.path, this.value)
       : assert(path != null),
@@ -2646,6 +2703,7 @@ abstract class LtPredicate implements Predicate {
   $LtPredicateCopyWith<LtPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $MissingPredicateCopyWith<$Res> {
   factory $MissingPredicateCopyWith(
           MissingPredicate value, $Res Function(MissingPredicate) then) =
@@ -2653,6 +2711,7 @@ abstract class $MissingPredicateCopyWith<$Res> {
   $Res call({PredicatePath path});
 }
 
+/// @nodoc
 class _$MissingPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $MissingPredicateCopyWith<$Res> {
   _$MissingPredicateCopyWithImpl(
@@ -2672,6 +2731,7 @@ class _$MissingPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$MissingPredicate implements MissingPredicate {
   _$MissingPredicate(this.path) : assert(path != null);
 
@@ -2919,6 +2979,7 @@ abstract class MissingPredicate implements Predicate {
   $MissingPredicateCopyWith<MissingPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $NearPredicateCopyWith<$Res> {
   factory $NearPredicateCopyWith(
           NearPredicate value, $Res Function(NearPredicate) then) =
@@ -2927,6 +2988,7 @@ abstract class $NearPredicateCopyWith<$Res> {
       {PredicatePath path, double latitude, double longitude, double radius});
 }
 
+/// @nodoc
 class _$NearPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $NearPredicateCopyWith<$Res> {
   _$NearPredicateCopyWithImpl(
@@ -2952,6 +3014,7 @@ class _$NearPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$NearPredicate implements NearPredicate {
   _$NearPredicate(this.path, this.latitude, this.longitude, this.radius)
       : assert(path != null),
@@ -3225,6 +3288,7 @@ abstract class NearPredicate implements Predicate {
   $NearPredicateCopyWith<NearPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $NotPredicateCopyWith<$Res> {
   factory $NotPredicateCopyWith(
           NotPredicate value, $Res Function(NotPredicate) then) =
@@ -3232,6 +3296,7 @@ abstract class $NotPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String value});
 }
 
+/// @nodoc
 class _$NotPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $NotPredicateCopyWith<$Res> {
   _$NotPredicateCopyWithImpl(
@@ -3253,6 +3318,7 @@ class _$NotPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$NotPredicate implements NotPredicate {
   _$NotPredicate(this.path, this.value)
       : assert(path != null),
@@ -3509,6 +3575,7 @@ abstract class NotPredicate implements Predicate {
   $NotPredicateCopyWith<NotPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $SimilarPredicateCopyWith<$Res> {
   factory $SimilarPredicateCopyWith(
           SimilarPredicate value, $Res Function(SimilarPredicate) then) =
@@ -3516,6 +3583,7 @@ abstract class $SimilarPredicateCopyWith<$Res> {
   $Res call({String id, int value});
 }
 
+/// @nodoc
 class _$SimilarPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
     implements $SimilarPredicateCopyWith<$Res> {
   _$SimilarPredicateCopyWithImpl(
@@ -3537,6 +3605,7 @@ class _$SimilarPredicateCopyWithImpl<$Res> extends _$PredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$SimilarPredicate implements SimilarPredicate {
   _$SimilarPredicate(this.id, this.value)
       : assert(id != null),
@@ -3793,6 +3862,7 @@ abstract class SimilarPredicate implements Predicate {
   $SimilarPredicateCopyWith<SimilarPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateAfterPredicateCopyWith<$Res> {
   factory $DateAfterPredicateCopyWith(
           DateAfterPredicate value, $Res Function(DateAfterPredicate) then) =
@@ -3800,6 +3870,7 @@ abstract class $DateAfterPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int epoch});
 }
 
+/// @nodoc
 class _$DateAfterPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateAfterPredicateCopyWith<$Res> {
@@ -3822,6 +3893,7 @@ class _$DateAfterPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateAfterPredicate implements DateAfterPredicate {
   _$DateAfterPredicate(this.path, this.epoch)
       : assert(path != null),
@@ -4079,6 +4151,7 @@ abstract class DateAfterPredicate implements Predicate {
   $DateAfterPredicateCopyWith<DateAfterPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateBeforePredicateCopyWith<$Res> {
   factory $DateBeforePredicateCopyWith(
           DateBeforePredicate value, $Res Function(DateBeforePredicate) then) =
@@ -4086,6 +4159,7 @@ abstract class $DateBeforePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int epoch});
 }
 
+/// @nodoc
 class _$DateBeforePredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateBeforePredicateCopyWith<$Res> {
@@ -4108,6 +4182,7 @@ class _$DateBeforePredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateBeforePredicate implements DateBeforePredicate {
   _$DateBeforePredicate(this.path, this.epoch)
       : assert(path != null),
@@ -4365,6 +4440,7 @@ abstract class DateBeforePredicate implements Predicate {
   $DateBeforePredicateCopyWith<DateBeforePredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateBetweenPredicateCopyWith<$Res> {
   factory $DateBetweenPredicateCopyWith(DateBetweenPredicate value,
           $Res Function(DateBetweenPredicate) then) =
@@ -4372,6 +4448,7 @@ abstract class $DateBetweenPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int startEpoch, int endEpoch});
 }
 
+/// @nodoc
 class _$DateBetweenPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateBetweenPredicateCopyWith<$Res> {
@@ -4396,6 +4473,7 @@ class _$DateBetweenPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateBetweenPredicate implements DateBetweenPredicate {
   _$DateBetweenPredicate(this.path, this.startEpoch, this.endEpoch)
       : assert(path != null),
@@ -4664,6 +4742,7 @@ abstract class DateBetweenPredicate implements Predicate {
   $DateBetweenPredicateCopyWith<DateBetweenPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfMonthPredicateCopyWith<$Res> {
   factory $DateDayOfMonthPredicateCopyWith(DateDayOfMonthPredicate value,
           $Res Function(DateDayOfMonthPredicate) then) =
@@ -4671,6 +4750,7 @@ abstract class $DateDayOfMonthPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int day});
 }
 
+/// @nodoc
 class _$DateDayOfMonthPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfMonthPredicateCopyWith<$Res> {
@@ -4693,6 +4773,7 @@ class _$DateDayOfMonthPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfMonthPredicate implements DateDayOfMonthPredicate {
   _$DateDayOfMonthPredicate(this.path, this.day)
       : assert(path != null),
@@ -4951,6 +5032,7 @@ abstract class DateDayOfMonthPredicate implements Predicate {
   $DateDayOfMonthPredicateCopyWith<DateDayOfMonthPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfMonthAfterPredicateCopyWith<$Res> {
   factory $DateDayOfMonthAfterPredicateCopyWith(
           DateDayOfMonthAfterPredicate value,
@@ -4959,6 +5041,7 @@ abstract class $DateDayOfMonthAfterPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int day});
 }
 
+/// @nodoc
 class _$DateDayOfMonthAfterPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfMonthAfterPredicateCopyWith<$Res> {
@@ -4983,6 +5066,7 @@ class _$DateDayOfMonthAfterPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfMonthAfterPredicate implements DateDayOfMonthAfterPredicate {
   _$DateDayOfMonthAfterPredicate(this.path, this.day)
       : assert(path != null),
@@ -5242,6 +5326,7 @@ abstract class DateDayOfMonthAfterPredicate implements Predicate {
       get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfMonthBeforePredicateCopyWith<$Res> {
   factory $DateDayOfMonthBeforePredicateCopyWith(
           DateDayOfMonthBeforePredicate value,
@@ -5250,6 +5335,7 @@ abstract class $DateDayOfMonthBeforePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int day});
 }
 
+/// @nodoc
 class _$DateDayOfMonthBeforePredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfMonthBeforePredicateCopyWith<$Res> {
@@ -5274,6 +5360,7 @@ class _$DateDayOfMonthBeforePredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfMonthBeforePredicate implements DateDayOfMonthBeforePredicate {
   _$DateDayOfMonthBeforePredicate(this.path, this.day)
       : assert(path != null),
@@ -5533,6 +5620,7 @@ abstract class DateDayOfMonthBeforePredicate implements Predicate {
       get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfWeekPredicateCopyWith<$Res> {
   factory $DateDayOfWeekPredicateCopyWith(DateDayOfWeekPredicate value,
           $Res Function(DateDayOfWeekPredicate) then) =
@@ -5540,6 +5628,7 @@ abstract class $DateDayOfWeekPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String day});
 }
 
+/// @nodoc
 class _$DateDayOfWeekPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfWeekPredicateCopyWith<$Res> {
@@ -5562,6 +5651,7 @@ class _$DateDayOfWeekPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfWeekPredicate implements DateDayOfWeekPredicate {
   _$DateDayOfWeekPredicate(this.path, this.day)
       : assert(path != null),
@@ -5820,6 +5910,7 @@ abstract class DateDayOfWeekPredicate implements Predicate {
   $DateDayOfWeekPredicateCopyWith<DateDayOfWeekPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfWeekAfterPredicateCopyWith<$Res> {
   factory $DateDayOfWeekAfterPredicateCopyWith(
           DateDayOfWeekAfterPredicate value,
@@ -5828,6 +5919,7 @@ abstract class $DateDayOfWeekAfterPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String day});
 }
 
+/// @nodoc
 class _$DateDayOfWeekAfterPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfWeekAfterPredicateCopyWith<$Res> {
@@ -5851,6 +5943,7 @@ class _$DateDayOfWeekAfterPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfWeekAfterPredicate implements DateDayOfWeekAfterPredicate {
   _$DateDayOfWeekAfterPredicate(this.path, this.day)
       : assert(path != null),
@@ -6110,6 +6203,7 @@ abstract class DateDayOfWeekAfterPredicate implements Predicate {
       get copyWith;
 }
 
+/// @nodoc
 abstract class $DateDayOfWeekBeforePredicateCopyWith<$Res> {
   factory $DateDayOfWeekBeforePredicateCopyWith(
           DateDayOfWeekBeforePredicate value,
@@ -6118,6 +6212,7 @@ abstract class $DateDayOfWeekBeforePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String day});
 }
 
+/// @nodoc
 class _$DateDayOfWeekBeforePredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateDayOfWeekBeforePredicateCopyWith<$Res> {
@@ -6142,6 +6237,7 @@ class _$DateDayOfWeekBeforePredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateDayOfWeekBeforePredicate implements DateDayOfWeekBeforePredicate {
   _$DateDayOfWeekBeforePredicate(this.path, this.day)
       : assert(path != null),
@@ -6401,6 +6497,7 @@ abstract class DateDayOfWeekBeforePredicate implements Predicate {
       get copyWith;
 }
 
+/// @nodoc
 abstract class $DateMonthPredicateCopyWith<$Res> {
   factory $DateMonthPredicateCopyWith(
           DateMonthPredicate value, $Res Function(DateMonthPredicate) then) =
@@ -6408,6 +6505,7 @@ abstract class $DateMonthPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String month});
 }
 
+/// @nodoc
 class _$DateMonthPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateMonthPredicateCopyWith<$Res> {
@@ -6430,6 +6528,7 @@ class _$DateMonthPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateMonthPredicate implements DateMonthPredicate {
   _$DateMonthPredicate(this.path, this.month)
       : assert(path != null),
@@ -6687,6 +6786,7 @@ abstract class DateMonthPredicate implements Predicate {
   $DateMonthPredicateCopyWith<DateMonthPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateMonthAfterPredicateCopyWith<$Res> {
   factory $DateMonthAfterPredicateCopyWith(DateMonthAfterPredicate value,
           $Res Function(DateMonthAfterPredicate) then) =
@@ -6694,6 +6794,7 @@ abstract class $DateMonthAfterPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String month});
 }
 
+/// @nodoc
 class _$DateMonthAfterPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateMonthAfterPredicateCopyWith<$Res> {
@@ -6716,6 +6817,7 @@ class _$DateMonthAfterPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateMonthAfterPredicate implements DateMonthAfterPredicate {
   _$DateMonthAfterPredicate(this.path, this.month)
       : assert(path != null),
@@ -6974,6 +7076,7 @@ abstract class DateMonthAfterPredicate implements Predicate {
   $DateMonthAfterPredicateCopyWith<DateMonthAfterPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateMonthBeforePredicateCopyWith<$Res> {
   factory $DateMonthBeforePredicateCopyWith(DateMonthBeforePredicate value,
           $Res Function(DateMonthBeforePredicate) then) =
@@ -6981,6 +7084,7 @@ abstract class $DateMonthBeforePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, String month});
 }
 
+/// @nodoc
 class _$DateMonthBeforePredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateMonthBeforePredicateCopyWith<$Res> {
@@ -7004,6 +7108,7 @@ class _$DateMonthBeforePredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateMonthBeforePredicate implements DateMonthBeforePredicate {
   _$DateMonthBeforePredicate(this.path, this.month)
       : assert(path != null),
@@ -7262,6 +7367,7 @@ abstract class DateMonthBeforePredicate implements Predicate {
   $DateMonthBeforePredicateCopyWith<DateMonthBeforePredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateYearPredicateCopyWith<$Res> {
   factory $DateYearPredicateCopyWith(
           DateYearPredicate value, $Res Function(DateYearPredicate) then) =
@@ -7269,6 +7375,7 @@ abstract class $DateYearPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int year});
 }
 
+/// @nodoc
 class _$DateYearPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateYearPredicateCopyWith<$Res> {
@@ -7291,6 +7398,7 @@ class _$DateYearPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateYearPredicate implements DateYearPredicate {
   _$DateYearPredicate(this.path, this.year)
       : assert(path != null),
@@ -7547,6 +7655,7 @@ abstract class DateYearPredicate implements Predicate {
   $DateYearPredicateCopyWith<DateYearPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateHourPredicateCopyWith<$Res> {
   factory $DateHourPredicateCopyWith(
           DateHourPredicate value, $Res Function(DateHourPredicate) then) =
@@ -7554,6 +7663,7 @@ abstract class $DateHourPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int hour});
 }
 
+/// @nodoc
 class _$DateHourPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateHourPredicateCopyWith<$Res> {
@@ -7576,6 +7686,7 @@ class _$DateHourPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateHourPredicate implements DateHourPredicate {
   _$DateHourPredicate(this.path, this.hour)
       : assert(path != null),
@@ -7832,6 +7943,7 @@ abstract class DateHourPredicate implements Predicate {
   $DateHourPredicateCopyWith<DateHourPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateHourAfterPredicateCopyWith<$Res> {
   factory $DateHourAfterPredicateCopyWith(DateHourAfterPredicate value,
           $Res Function(DateHourAfterPredicate) then) =
@@ -7839,6 +7951,7 @@ abstract class $DateHourAfterPredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int hour});
 }
 
+/// @nodoc
 class _$DateHourAfterPredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateHourAfterPredicateCopyWith<$Res> {
@@ -7861,6 +7974,7 @@ class _$DateHourAfterPredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateHourAfterPredicate implements DateHourAfterPredicate {
   _$DateHourAfterPredicate(this.path, this.hour)
       : assert(path != null),
@@ -8119,6 +8233,7 @@ abstract class DateHourAfterPredicate implements Predicate {
   $DateHourAfterPredicateCopyWith<DateHourAfterPredicate> get copyWith;
 }
 
+/// @nodoc
 abstract class $DateHourBeforePredicateCopyWith<$Res> {
   factory $DateHourBeforePredicateCopyWith(DateHourBeforePredicate value,
           $Res Function(DateHourBeforePredicate) then) =
@@ -8126,6 +8241,7 @@ abstract class $DateHourBeforePredicateCopyWith<$Res> {
   $Res call({PredicatePath path, int hour});
 }
 
+/// @nodoc
 class _$DateHourBeforePredicateCopyWithImpl<$Res>
     extends _$PredicateCopyWithImpl<$Res>
     implements $DateHourBeforePredicateCopyWith<$Res> {
@@ -8148,6 +8264,7 @@ class _$DateHourBeforePredicateCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 class _$DateHourBeforePredicate implements DateHourBeforePredicate {
   _$DateHourBeforePredicate(this.path, this.hour)
       : assert(path != null),

--- a/packages/flusmic/lib/src/models/response/flusmic_response.freezed.dart
+++ b/packages/flusmic/lib/src/models/response/flusmic_response.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'flusmic_response.dart';
 
@@ -12,9 +12,11 @@ FlusmicResponse _$FlusmicResponseFromJson(Map<String, dynamic> json) {
   return _FlusmicResponse.fromJson(json);
 }
 
+/// @nodoc
 class _$FlusmicResponseTearOff {
   const _$FlusmicResponseTearOff();
 
+// ignore: unused_element
   _FlusmicResponse call(
       {@JsonKey(name: 'next_page') String nextPage,
       @JsonKey(name: 'prev_page') String prevPage,
@@ -39,11 +41,18 @@ class _$FlusmicResponseTearOff {
       page: page,
     );
   }
+
+// ignore: unused_element
+  FlusmicResponse fromJson(Map<String, Object> json) {
+    return FlusmicResponse.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $FlusmicResponse = _$FlusmicResponseTearOff();
 
+/// @nodoc
 mixin _$FlusmicResponse {
   @JsonKey(name: 'next_page')
   String get nextPage;
@@ -66,6 +75,7 @@ mixin _$FlusmicResponse {
   $FlusmicResponseCopyWith<FlusmicResponse> get copyWith;
 }
 
+/// @nodoc
 abstract class $FlusmicResponseCopyWith<$Res> {
   factory $FlusmicResponseCopyWith(
           FlusmicResponse value, $Res Function(FlusmicResponse) then) =
@@ -83,6 +93,7 @@ abstract class $FlusmicResponseCopyWith<$Res> {
       int page});
 }
 
+/// @nodoc
 class _$FlusmicResponseCopyWithImpl<$Res>
     implements $FlusmicResponseCopyWith<$Res> {
   _$FlusmicResponseCopyWithImpl(this._value, this._then);
@@ -124,6 +135,7 @@ class _$FlusmicResponseCopyWithImpl<$Res>
   }
 }
 
+/// @nodoc
 abstract class _$FlusmicResponseCopyWith<$Res>
     implements $FlusmicResponseCopyWith<$Res> {
   factory _$FlusmicResponseCopyWith(
@@ -143,6 +155,7 @@ abstract class _$FlusmicResponseCopyWith<$Res>
       int page});
 }
 
+/// @nodoc
 class __$FlusmicResponseCopyWithImpl<$Res>
     extends _$FlusmicResponseCopyWithImpl<$Res>
     implements _$FlusmicResponseCopyWith<$Res> {
@@ -187,6 +200,8 @@ class __$FlusmicResponseCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_FlusmicResponse implements _FlusmicResponse {
   _$_FlusmicResponse(
       {@JsonKey(name: 'next_page') this.nextPage,

--- a/packages/flusmic/lib/src/models/types/richable/embed/embed_data.freezed.dart
+++ b/packages/flusmic/lib/src/models/types/richable/embed/embed_data.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'embed_data.dart';
 
@@ -12,9 +12,11 @@ EmbedData _$EmbedDataFromJson(Map<String, dynamic> json) {
   return _EmbedData.fromJson(json);
 }
 
+/// @nodoc
 class _$EmbedDataTearOff {
   const _$EmbedDataTearOff();
 
+// ignore: unused_element
   _EmbedData call(
       {@required @JsonKey(name: 'author_name') String authorName,
       @required @JsonKey(name: 'author_url') String authorUrl,
@@ -47,11 +49,18 @@ class _$EmbedDataTearOff {
       width: width,
     );
   }
+
+// ignore: unused_element
+  EmbedData fromJson(Map<String, Object> json) {
+    return EmbedData.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $EmbedData = _$EmbedDataTearOff();
 
+/// @nodoc
 mixin _$EmbedData {
   @JsonKey(name: 'author_name')
   String get authorName;
@@ -80,6 +89,7 @@ mixin _$EmbedData {
   $EmbedDataCopyWith<EmbedData> get copyWith;
 }
 
+/// @nodoc
 abstract class $EmbedDataCopyWith<$Res> {
   factory $EmbedDataCopyWith(EmbedData value, $Res Function(EmbedData) then) =
       _$EmbedDataCopyWithImpl<$Res>;
@@ -100,6 +110,7 @@ abstract class $EmbedDataCopyWith<$Res> {
       double width});
 }
 
+/// @nodoc
 class _$EmbedDataCopyWithImpl<$Res> implements $EmbedDataCopyWith<$Res> {
   _$EmbedDataCopyWithImpl(this._value, this._then);
 
@@ -153,6 +164,7 @@ class _$EmbedDataCopyWithImpl<$Res> implements $EmbedDataCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$EmbedDataCopyWith<$Res> implements $EmbedDataCopyWith<$Res> {
   factory _$EmbedDataCopyWith(
           _EmbedData value, $Res Function(_EmbedData) then) =
@@ -175,6 +187,7 @@ abstract class _$EmbedDataCopyWith<$Res> implements $EmbedDataCopyWith<$Res> {
       double width});
 }
 
+/// @nodoc
 class __$EmbedDataCopyWithImpl<$Res> extends _$EmbedDataCopyWithImpl<$Res>
     implements _$EmbedDataCopyWith<$Res> {
   __$EmbedDataCopyWithImpl(_EmbedData _value, $Res Function(_EmbedData) _then)
@@ -230,6 +243,8 @@ class __$EmbedDataCopyWithImpl<$Res> extends _$EmbedDataCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_EmbedData implements _EmbedData {
   _$_EmbedData(
       {@required @JsonKey(name: 'author_name') this.authorName,

--- a/packages/flusmic/lib/src/models/types/simple/geopoint/geopoint.freezed.dart
+++ b/packages/flusmic/lib/src/models/types/simple/geopoint/geopoint.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'geopoint.dart';
 
@@ -12,20 +12,29 @@ Geopoint _$GeopointFromJson(Map<String, dynamic> json) {
   return _Geopoint.fromJson(json);
 }
 
+/// @nodoc
 class _$GeopointTearOff {
   const _$GeopointTearOff();
 
+// ignore: unused_element
   _Geopoint call({@required double latitude, @required double longitude}) {
     return _Geopoint(
       latitude: latitude,
       longitude: longitude,
     );
   }
+
+// ignore: unused_element
+  Geopoint fromJson(Map<String, Object> json) {
+    return Geopoint.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Geopoint = _$GeopointTearOff();
 
+/// @nodoc
 mixin _$Geopoint {
   double get latitude;
   double get longitude;
@@ -34,12 +43,14 @@ mixin _$Geopoint {
   $GeopointCopyWith<Geopoint> get copyWith;
 }
 
+/// @nodoc
 abstract class $GeopointCopyWith<$Res> {
   factory $GeopointCopyWith(Geopoint value, $Res Function(Geopoint) then) =
       _$GeopointCopyWithImpl<$Res>;
   $Res call({double latitude, double longitude});
 }
 
+/// @nodoc
 class _$GeopointCopyWithImpl<$Res> implements $GeopointCopyWith<$Res> {
   _$GeopointCopyWithImpl(this._value, this._then);
 
@@ -59,6 +70,7 @@ class _$GeopointCopyWithImpl<$Res> implements $GeopointCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$GeopointCopyWith<$Res> implements $GeopointCopyWith<$Res> {
   factory _$GeopointCopyWith(_Geopoint value, $Res Function(_Geopoint) then) =
       __$GeopointCopyWithImpl<$Res>;
@@ -66,6 +78,7 @@ abstract class _$GeopointCopyWith<$Res> implements $GeopointCopyWith<$Res> {
   $Res call({double latitude, double longitude});
 }
 
+/// @nodoc
 class __$GeopointCopyWithImpl<$Res> extends _$GeopointCopyWithImpl<$Res>
     implements _$GeopointCopyWith<$Res> {
   __$GeopointCopyWithImpl(_Geopoint _value, $Res Function(_Geopoint) _then)
@@ -87,6 +100,8 @@ class __$GeopointCopyWithImpl<$Res> extends _$GeopointCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Geopoint implements _Geopoint {
   _$_Geopoint({@required this.latitude, @required this.longitude})
       : assert(latitude != null),

--- a/packages/flusmic/lib/src/models/types/simple/slice/slice.freezed.dart
+++ b/packages/flusmic/lib/src/models/types/simple/slice/slice.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'slice.dart';
 
@@ -12,9 +12,11 @@ Slice _$SliceFromJson(Map<String, dynamic> json) {
   return _Slice.fromJson(json);
 }
 
+/// @nodoc
 class _$SliceTearOff {
   const _$SliceTearOff();
 
+// ignore: unused_element
   _Slice call(
       {@JsonKey(name: 'slice_label') String sliceLabel,
       @required @JsonKey(name: 'slice_type') String sliceType,
@@ -27,11 +29,18 @@ class _$SliceTearOff {
       primary: primary,
     );
   }
+
+// ignore: unused_element
+  Slice fromJson(Map<String, Object> json) {
+    return Slice.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Slice = _$SliceTearOff();
 
+/// @nodoc
 mixin _$Slice {
   @JsonKey(name: 'slice_label')
   String get sliceLabel;
@@ -44,6 +53,7 @@ mixin _$Slice {
   $SliceCopyWith<Slice> get copyWith;
 }
 
+/// @nodoc
 abstract class $SliceCopyWith<$Res> {
   factory $SliceCopyWith(Slice value, $Res Function(Slice) then) =
       _$SliceCopyWithImpl<$Res>;
@@ -54,6 +64,7 @@ abstract class $SliceCopyWith<$Res> {
       Map<String, dynamic> primary});
 }
 
+/// @nodoc
 class _$SliceCopyWithImpl<$Res> implements $SliceCopyWith<$Res> {
   _$SliceCopyWithImpl(this._value, this._then);
 
@@ -80,6 +91,7 @@ class _$SliceCopyWithImpl<$Res> implements $SliceCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$SliceCopyWith<$Res> implements $SliceCopyWith<$Res> {
   factory _$SliceCopyWith(_Slice value, $Res Function(_Slice) then) =
       __$SliceCopyWithImpl<$Res>;
@@ -91,6 +103,7 @@ abstract class _$SliceCopyWith<$Res> implements $SliceCopyWith<$Res> {
       Map<String, dynamic> primary});
 }
 
+/// @nodoc
 class __$SliceCopyWithImpl<$Res> extends _$SliceCopyWithImpl<$Res>
     implements _$SliceCopyWith<$Res> {
   __$SliceCopyWithImpl(_Slice _value, $Res Function(_Slice) _then)
@@ -119,6 +132,8 @@ class __$SliceCopyWithImpl<$Res> extends _$SliceCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Slice implements _Slice {
   _$_Slice(
       {@JsonKey(name: 'slice_label') this.sliceLabel,

--- a/packages/flusmic/lib/src/models/types/simple/span/span.freezed.dart
+++ b/packages/flusmic/lib/src/models/types/simple/span/span.freezed.dart
@@ -1,5 +1,5 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
 
 part of 'span.dart';
 
@@ -12,9 +12,11 @@ Span _$SpanFromJson(Map<String, dynamic> json) {
   return _Span.fromJson(json);
 }
 
+/// @nodoc
 class _$SpanTearOff {
   const _$SpanTearOff();
 
+// ignore: unused_element
   _Span call({@required String type, @required int end, @required int start}) {
     return _Span(
       type: type,
@@ -22,11 +24,18 @@ class _$SpanTearOff {
       start: start,
     );
   }
+
+// ignore: unused_element
+  Span fromJson(Map<String, Object> json) {
+    return Span.fromJson(json);
+  }
 }
 
+/// @nodoc
 // ignore: unused_element
 const $Span = _$SpanTearOff();
 
+/// @nodoc
 mixin _$Span {
   String get type;
   int get end;
@@ -36,12 +45,14 @@ mixin _$Span {
   $SpanCopyWith<Span> get copyWith;
 }
 
+/// @nodoc
 abstract class $SpanCopyWith<$Res> {
   factory $SpanCopyWith(Span value, $Res Function(Span) then) =
       _$SpanCopyWithImpl<$Res>;
   $Res call({String type, int end, int start});
 }
 
+/// @nodoc
 class _$SpanCopyWithImpl<$Res> implements $SpanCopyWith<$Res> {
   _$SpanCopyWithImpl(this._value, this._then);
 
@@ -63,6 +74,7 @@ class _$SpanCopyWithImpl<$Res> implements $SpanCopyWith<$Res> {
   }
 }
 
+/// @nodoc
 abstract class _$SpanCopyWith<$Res> implements $SpanCopyWith<$Res> {
   factory _$SpanCopyWith(_Span value, $Res Function(_Span) then) =
       __$SpanCopyWithImpl<$Res>;
@@ -70,6 +82,7 @@ abstract class _$SpanCopyWith<$Res> implements $SpanCopyWith<$Res> {
   $Res call({String type, int end, int start});
 }
 
+/// @nodoc
 class __$SpanCopyWithImpl<$Res> extends _$SpanCopyWithImpl<$Res>
     implements _$SpanCopyWith<$Res> {
   __$SpanCopyWithImpl(_Span _value, $Res Function(_Span) _then)
@@ -93,6 +106,8 @@ class __$SpanCopyWithImpl<$Res> extends _$SpanCopyWithImpl<$Res>
 }
 
 @JsonSerializable()
+
+/// @nodoc
 class _$_Span implements _Span {
   _$_Span({@required this.type, @required this.end, @required this.start})
       : assert(type != null),

--- a/packages/flusmic/pubspec.lock
+++ b/packages/flusmic/pubspec.lock
@@ -7,14 +7,14 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.0"
+    version: "12.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.39.8"
+    version: "0.40.6"
   args:
     dependency: transitive
     description:
@@ -28,21 +28,21 @@ packages:
       name: async
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.4.0"
+    version: "2.5.0-nullsafety.2"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "2.1.0-nullsafety.2"
   build:
     dependency: transitive
     description:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.0"
+    version: "1.5.0"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.9"
+    version: "1.4.3"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.0"
+    version: "1.10.4"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.2.0"
+    version: "6.0.3"
   built_collection:
     dependency: transitive
     description:
@@ -98,7 +98,7 @@ packages:
       name: charcode
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.2"
+    version: "1.2.0-nullsafety.2"
   checked_yaml:
     dependency: transitive
     description:
@@ -106,20 +106,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.2"
+  cli_util:
+    dependency: transitive
+    description:
+      name: cli_util
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.0"
   code_builder:
     dependency: transitive
     description:
       name: code_builder
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.2.1"
+    version: "3.5.0"
   collection:
     dependency: transitive
     description:
       name: collection
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.11"
+    version: "1.15.0-nullsafety.4"
   convert:
     dependency: transitive
     description:
@@ -133,7 +140,7 @@ packages:
       name: coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.13.9"
+    version: "0.14.2"
   crypto:
     dependency: transitive
     description:
@@ -141,34 +148,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.3"
-  csslib:
-    dependency: transitive
-    description:
-      name: csslib
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.16.1"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.6"
+    version: "1.3.9"
   dio:
     dependency: "direct main"
     description:
       name: dio
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.9"
+    version: "3.0.10"
   effective_dart:
     dependency: "direct dev"
     description:
       name: effective_dart
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.2.2"
+    version: "1.3.0"
   fixnum:
     dependency: transitive
     description:
@@ -182,14 +182,14 @@ packages:
       name: freezed
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0"
+    version: "0.12.2"
   freezed_annotation:
     dependency: "direct main"
     description:
       name: freezed_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.11.0"
+    version: "0.12.0"
   glob:
     dependency: transitive
     description:
@@ -204,13 +204,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  html:
-    dependency: transitive
-    description:
-      name: html
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "0.14.0+3"
   http:
     dependency: transitive
     description:
@@ -245,21 +238,21 @@ packages:
       name: js
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.6.1+1"
+    version: "0.6.3-nullsafety.2"
   json_annotation:
     dependency: "direct main"
     description:
       name: json_annotation
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.0.1"
+    version: "3.1.0"
   json_serializable:
     dependency: "direct dev"
     description:
       name: json_serializable
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.3.0"
+    version: "3.5.0"
   lcov:
     dependency: transitive
     description:
@@ -280,14 +273,14 @@ packages:
       name: matcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.6"
+    version: "0.12.10-nullsafety.2"
   meta:
     dependency: "direct main"
     description:
       name: meta
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.8"
+    version: "1.3.0-nullsafety.5"
   mime:
     dependency: transitive
     description:
@@ -301,21 +294,14 @@ packages:
       name: mockito
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.1.1"
-  multi_server_socket:
-    dependency: transitive
-    description:
-      name: multi_server_socket
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.2"
+    version: "4.1.3"
   nock:
     dependency: "direct dev"
     description:
       name: nock
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.2"
+    version: "1.1.2"
   node_interop:
     dependency: transitive
     description:
@@ -357,21 +343,21 @@ packages:
       name: path
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.6.4"
+    version: "1.8.0-nullsafety.2"
   pedantic:
     dependency: transitive
     description:
       name: pedantic
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.8.0+1"
+    version: "1.10.0-nullsafety.2"
   pool:
     dependency: transitive
     description:
       name: pool
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.0"
+    version: "1.5.0-nullsafety.2"
   pub_semver:
     dependency: transitive
     description:
@@ -427,42 +413,42 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.5"
+    version: "0.9.8"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.3"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.10.9"
+    version: "0.10.10-nullsafety.2"
   source_span:
     dependency: transitive
     description:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.5"
+    version: "1.8.0-nullsafety.2"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.9.3"
+    version: "1.10.0-nullsafety.5"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0-nullsafety.2"
   stream_transform:
     dependency: transitive
     description:
@@ -476,42 +462,42 @@ packages:
       name: string_scanner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.5"
+    version: "1.1.0-nullsafety.2"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0-nullsafety.2"
   test:
     dependency: "direct dev"
     description:
       name: test
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.14.7"
+    version: "1.16.0-nullsafety.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.16"
+    version: "0.2.19-nullsafety.4"
   test_core:
     dependency: transitive
     description:
       name: test_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.7"
+    version: "0.3.12-nullsafety.7"
   test_coverage:
     dependency: "direct dev"
     description:
       name: test_coverage
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.1"
+    version: "0.5.0"
   timing:
     dependency: transitive
     description:
@@ -525,7 +511,7 @@ packages:
       name: typed_data
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.1.6"
+    version: "1.3.0-nullsafety.4"
   vm_service:
     dependency: transitive
     description:
@@ -562,4 +548,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.7.0 <3.0.0"
+  dart: ">=2.10.0 <2.11.0"

--- a/packages/flusmic/pubspec.lock
+++ b/packages/flusmic/pubspec.lock
@@ -7,21 +7,21 @@ packages:
       name: _fe_analyzer_shared
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "12.0.0"
+    version: "7.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.40.6"
+    version: "0.39.17"
   args:
     dependency: transitive
     description:
       name: args
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.2"
+    version: "1.6.0"
   async:
     dependency: transitive
     description:
@@ -42,7 +42,7 @@ packages:
       name: build
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.5.0"
+    version: "1.3.0"
   build_config:
     dependency: transitive
     description:
@@ -63,21 +63,21 @@ packages:
       name: build_resolvers
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.3"
+    version: "1.3.11"
   build_runner:
     dependency: "direct dev"
     description:
       name: build_runner
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.10.4"
+    version: "1.10.0"
   build_runner_core:
     dependency: transitive
     description:
       name: build_runner_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.3"
+    version: "5.2.0"
   built_collection:
     dependency: transitive
     description:
@@ -147,14 +147,21 @@ packages:
       name: crypto
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.5"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.16.2"
   dart_style:
     dependency: transitive
     description:
       name: dart_style
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.3.9"
+    version: "1.3.6"
   dio:
     dependency: "direct main"
     description:
@@ -204,13 +211,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.2.0"
-  http:
+  html:
     dependency: transitive
     description:
-      name: http
+      name: html
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.1"
+    version: "0.14.0+4"
   http_multi_server:
     dependency: transitive
     description:
@@ -287,7 +294,7 @@ packages:
       name: mime
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.6+3"
+    version: "0.9.7"
   mockito:
     dependency: "direct dev"
     description:
@@ -308,21 +315,21 @@ packages:
       name: node_interop
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.3"
+    version: "1.2.0"
   node_io:
     dependency: transitive
     description:
       name: node_io
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1+2"
+    version: "1.1.1"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.8"
+    version: "1.4.12"
   package_config:
     dependency: transitive
     description:
@@ -330,13 +337,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.9.3"
-  package_resolver:
-    dependency: transitive
-    description:
-      name: package_resolver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "1.0.10"
   path:
     dependency: transitive
     description:
@@ -378,21 +378,21 @@ packages:
       name: quiver
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.5"
+    version: "2.1.5"
   shelf:
     dependency: transitive
     description:
       name: shelf
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.7.5"
+    version: "0.7.9"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.4"
+    version: "2.0.0"
   shelf_static:
     dependency: transitive
     description:
@@ -413,7 +413,7 @@ packages:
       name: source_gen
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.9.8"
+    version: "0.9.7+1"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -518,7 +518,7 @@ packages:
       name: vm_service
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.3.1"
+    version: "5.5.0"
   watcher:
     dependency: transitive
     description:
@@ -539,7 +539,7 @@ packages:
       name: webkit_inspection_protocol
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.3"
+    version: "0.7.4"
   yaml:
     dependency: transitive
     description:
@@ -548,4 +548,4 @@ packages:
     source: hosted
     version: "2.2.1"
 sdks:
-  dart: ">=2.10.0 <2.11.0"
+  dart: ">=2.10.0-78 <2.11.0"

--- a/packages/flusmic/pubspec.yaml
+++ b/packages/flusmic/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flusmic
 description: A functional and kind of elegant Prismic.io integration for Dart and Flutter.
-version: 2.0.0+2
+version: 2.1.0
 repository: https://github.com/PixelaGt/flusmic
 issue_tracker: https://github.com/PixelaGt/flusmic/issues
 homepage: https://github.com/PixelaGt/flusmic

--- a/packages/flusmic/pubspec.yaml
+++ b/packages/flusmic/pubspec.yaml
@@ -6,20 +6,20 @@ issue_tracker: https://github.com/PixelaGt/flusmic/issues
 homepage: https://github.com/PixelaGt/flusmic
 
 environment:
-  sdk: ">=2.3.0 <3.0.0"
+  sdk: ">=2.7.0 <3.0.0"
 
 dependencies:
-  dio: ^3.0.9
-  freezed_annotation: ^0.11.0
-  json_annotation: ^3.0.1
-  meta: ^1.1.8
+  dio: ^3.0.10
+  freezed_annotation: ^0.12.0
+  json_annotation: ^3.1.0
+  meta: ^1.2.3
 
 dev_dependencies:
-  build_runner: ^1.10.0
-  effective_dart: ^1.2.2
-  freezed: ^0.11.0
-  json_serializable: ^3.3.0
-  mockito: ^4.1.1
-  nock: ^1.0.2
-  test: ^1.14.7
-  test_coverage: ^0.4.1
+  build_runner: ^1.10.4
+  effective_dart: ^1.3.0
+  freezed: ^0.12.2
+  json_serializable: ^3.5.0
+  mockito: ^4.1.3
+  nock: ^1.1.2
+  test: ^1.15.5
+  test_coverage: ^0.5.0

--- a/packages/flusmic/pubspec.yaml
+++ b/packages/flusmic/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   meta: ^1.2.3
 
 dev_dependencies:
-  build_runner: ^1.10.4
+  build_runner: 1.10.0
   effective_dart: ^1.3.0
   freezed: ^0.12.2
   json_serializable: ^3.5.0

--- a/packages/flusmic/test/error_flusmic_test.dart
+++ b/packages/flusmic/test/error_flusmic_test.dart
@@ -69,6 +69,21 @@ void main() {
             throwsA(isA<FlusmicError>().having((e) => e.code, 'unknown', 100)));
       }, createHttpClient: (context) => MockClient());
     });
+
+    test('Unknown exception for query', () async {
+      await HttpOverrides.runZoned(() {
+        nock('https://flusmic.cdn.prismic.io').get(equals('/api/v2'))
+          ..replay(200, apiResponse,
+              headers: {'Content-Type': 'application/json'});
+        nock('https://flusmic.cdn.prismic.io')
+            .get(contains('/api/v2/documents/search?ref='))
+              ..replay(422, 'date');
+        final flusmic =
+            Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
+        expect(() async => await flusmic.getRootDocument(),
+            throwsA(isA<FlusmicError>().having((e) => e.code, 'unknown', 100)));
+      }, createHttpClient: (context) => MockClient());
+    });
   });
 }
 

--- a/packages/flusmic/test/error_flusmic_test.dart
+++ b/packages/flusmic/test/error_flusmic_test.dart
@@ -10,7 +10,7 @@ void main() {
     test('bad request exception', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get("/api/v2")
-          ..replay(400, 'data');
+          ..reply(400, 'data');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(
@@ -23,7 +23,7 @@ void main() {
     test('unauthorized exception', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get("/api/v2")
-          ..replay(401, 'data');
+          ..reply(401, 'data');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(
@@ -36,7 +36,7 @@ void main() {
     test('forbidden exception', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get("/api/v2")
-          ..replay(403, 'data');
+          ..reply(403, 'data');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(
@@ -49,7 +49,7 @@ void main() {
     test('server error exception', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get("/api/v2")
-          ..replay(500, 'data');
+          ..reply(500, 'data');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(
@@ -62,7 +62,7 @@ void main() {
     test('Unknown exception', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get("/api/v2")
-          ..replay(422, 'data');
+          ..reply(422, 'data');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(() async => await flusmic.getApi(),
@@ -73,11 +73,11 @@ void main() {
     test('Unknown exception for query', () async {
       await HttpOverrides.runZoned(() {
         nock('https://flusmic.cdn.prismic.io').get(equals('/api/v2'))
-          ..replay(200, apiResponse,
+          ..reply(200, apiResponse,
               headers: {'Content-Type': 'application/json'});
         nock('https://flusmic.cdn.prismic.io')
             .get(contains('/api/v2/documents/search?ref='))
-              ..replay(422, 'date');
+              ..reply(422, 'date');
         final flusmic =
             Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
         expect(() async => await flusmic.getRootDocument(),

--- a/packages/flusmic/test/search_query_flusmic_test.dart
+++ b/packages/flusmic/test/search_query_flusmic_test.dart
@@ -53,13 +53,6 @@ void main() {
       expect(result.results.length, 2);
     });
 
-    test('orderings', () async {
-      final result = await flusmic.query(
-          [Predicate.at(DefaultPredicatePath.type(), 'test')],
-          orderings: [Ordering('test', 'number')]);
-      expect(result.results.length, 2);
-    });
-
     test('page', () async {
       final result = await flusmic
           .query([Predicate.at(DefaultPredicatePath.type(), 'test')], page: 1);
@@ -70,6 +63,65 @@ void main() {
       final result = await flusmic.query(
           [Predicate.at(DefaultPredicatePath.type(), 'test')],
           pageSize: 2);
+      expect(result.results.length, 2);
+    });
+  });
+
+  group('ordering with flusmic', () {
+    final flusmic =
+        Flusmic(prismicEndpoint: 'https://flusmic.cdn.prismic.io/api/v2');
+    test('document orderings', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.document('first_publication_date')]);
+      expect(result.results.length, 2);
+    });
+    test('document orderings desc', () async {
+      final result = await flusmic.query([
+        Predicate.at(DefaultPredicatePath.type(), 'test')
+      ], orderings: [
+        Ordering.document('first_publication_date', descending: true)
+      ]);
+      expect(result.results.length, 2);
+    });
+    test('first publication date orderings', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.firstPublicationDate()]);
+      expect(result.results.length, 2);
+    });
+
+    test('first publication date orderings desc', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.firstPublicationDate(descending: true)]);
+      expect(result.results.length, 2);
+    });
+
+    test('last publication date orderings', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.lastPublicationDate()]);
+      expect(result.results.length, 2);
+    });
+
+    test('last publication date orderings desc', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.lastPublicationDate(descending: true)]);
+      expect(result.results.length, 2);
+    });
+    test('type orderings', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.type('test', 'number')]);
+      expect(result.results.length, 2);
+    });
+
+    test('type orderings desc', () async {
+      final result = await flusmic.query(
+          [Predicate.at(DefaultPredicatePath.type(), 'test')],
+          orderings: [Ordering.type('test', 'number', descending: true)]);
       expect(result.results.length, 2);
     });
   });


### PR DESCRIPTION
- **BREAKING**: Change `Ordering` constructors to `type`, `document`, `firstPublicationDate` and `lastPublicationDate` 
- Fix 'des' issue with orderings
- 'page' param for `getRootDocument` and `getDocumentsByType` methods
- Update dependencies.

Solves #13 and #14 