### PR TITLE
Add toString override to flusmic error

### DIFF
--- a/packages/flusmic/lib/src/flusmic_error.dart
+++ b/packages/flusmic/lib/src/flusmic_error.dart
@@ -63,6 +63,11 @@ class FlusmicError implements Exception {
         );
     }
   }
+  
+  @override
+  String toString() {
+    return 'FlusmicError{code: $code, humanMessage: $humanMessage, message: $message, response: $response}';
+  }
 
   ///Response from failed request
   final dynamic response;


### PR DESCRIPTION
This will avoir having `Instance of FlusmicError` reported on sentry and actually have information of what have got badly.