### PR TITLE
Add support for graph query

### DIFF
--- a/packages/flusmic/lib/src/flusmic_repository.dart
+++ b/packages/flusmic/lib/src/flusmic_repository.dart
@@ -72,6 +72,7 @@ class Flusmic {
     String? language,
     int? page,
     int? pageSize,
+    String? graphQuery,
   }) async {
     try {
       final api = await getApi(authToken: authToken);
@@ -86,6 +87,7 @@ class Flusmic {
           orderings: orderings,
           page: page,
           pageSize: pageSize,
+          graphQuery: graphQuery,
         ),
       );
       return FlusmicResponse.fromJson(response.data as Map<String, dynamic>);
@@ -147,6 +149,7 @@ class Flusmic {
     String? after,
     String? authToken,
     String? language,
+    String? graphQuery,
   }) =>
       <String, dynamic>{
         if (after?.isNotEmpty ?? false) 'after': after,
@@ -161,6 +164,7 @@ class Flusmic {
               '[${orderings?.map(_generateOrdering).toList().join(',')}]',
         if (page != null) 'page': page.toString(),
         if (pageSize != null) 'pageSize': pageSize.toString(),
+        if (graphQuery?.isNotEmpty ?? false) 'graphQuery': graphQuery,
       };
 
   ///Generate the API url to perform a request.


### PR DESCRIPTION
Prismic, using the `graphQuery` parameter, allow us to do selective fetching. We can retrieve only the fields we want to and it adds other features ([see documentation about `graphQuery`](https://prismic.io/docs/technologies/graphquery-rest-api)).

This PR add the missing field to support `graphQuery`.